### PR TITLE
fix: align package.json license with repo license files

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "repository": "https://github.com/iden3/react-native-rapidsnark",
   "homepage": "https://github.com/iden3/react-native-rapidsnark",
   "author": "demonsh <dmytro.sukhiy@gmail.com>",
-  "license": "GPL-3.0",
+  "license": "(MIT OR Apache-2.0)",
   "bugs": {
     "url": "https://github.com/iden3/react-native-rapidsnark/issues"
   },


### PR DESCRIPTION
This PR updates the `license` field in `package.json`.

Today the package metadata says `GPL-3.0`, but the repository already documents the project as dual-licensed under MIT and Apache-2.0:
- `LICENSE-MIT`
- `LICENSE-APACHE`
- README license section

That mismatch causes confusion for downstream users and license scanners, especially because npm consumers rely on the `package.json` license field as package metadata.

Change in this PR:
- `license: "GPL-3.0"` -> `license: "(MIT OR Apache-2.0)"`

This only aligns the package metadata with the existing repository license files and README.

If this looks right, it would also be helpful to publish a patched npm release so downstream users pick up the corrected metadata.
